### PR TITLE
Update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/jusgglinmike/ractive-adaptors-ampersand.git"
+		"url": "https://github.com/ractivejs/ractive-adaptors-ampersand.git"
 	},
 	"scripts": {
 		"test": "jshint ractive-adaptors-ampersand.js && mocha",


### PR DESCRIPTION
Reference the Ractive.js-owned repository in the project's `package.json` file (looks like I had a typo in my version anyway)
